### PR TITLE
Load protocolservers from resources instead of local folder

### DIFF
--- a/src/test/java/no/ntnu/okse/core/CoreServiceTest.java
+++ b/src/test/java/no/ntnu/okse/core/CoreServiceTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutorService;
@@ -55,7 +56,8 @@ public class CoreServiceTest {
         ArrayList<ProtocolServer> ps = (ArrayList<ProtocolServer>)field.get(cs);
         ps.clear();
         cs.protocolServersBooted = false;
-        cs.bootProtocolServers();
+        InputStream resourceAsStream = CoreService.class.getResourceAsStream("/config/protocolservers.xml");
+        cs.bootProtocolServers(resourceAsStream);
     }
 
     @BeforeMethod

--- a/src/test/java/no/ntnu/okse/protocol/MessageSendingTest.java
+++ b/src/test/java/no/ntnu/okse/protocol/MessageSendingTest.java
@@ -60,7 +60,7 @@ public class MessageSendingTest {
         publisher.connect();
         subscriber.subscribe("mqtt");
 
-        verify(subscriptionMock, timeout(500)).subscriptionChanged(any());
+        verify(subscriptionMock, timeout(500).atLeastOnce()).subscriptionChanged(any());
 
         publisher.publish("mqtt", "Text content");
         Thread.sleep(2000);
@@ -79,7 +79,7 @@ public class MessageSendingTest {
         subscriber.setCallback(callback);
         subscriber.subscribe("amqp");
 
-        verify(subscriptionMock, timeout(500)).subscriptionChanged(any());
+        verify(subscriptionMock, timeout(500).atLeastOnce()).subscriptionChanged(any());
 
         publisher.publish("amqp", "Text content");
         publisher.disconnect();
@@ -99,7 +99,7 @@ public class MessageSendingTest {
         subscriber.setConsumer(consumer);
         subscriber.subscribe("amqp091");
 
-        verify(subscriptionMock, timeout(500)).subscriptionChanged(any());
+        verify(subscriptionMock, timeout(500).atLeastOnce()).subscriptionChanged(any());
 
         publisher.publish("amqp091", "Text content");
         Thread.sleep(2000);
@@ -162,7 +162,7 @@ public class MessageSendingTest {
         amqp091Client.subscribe("all");
         amqpClient.subscribe("all");
 
-        verify(subscriptionMock, timeout(500).times(numberOfProtocols)).subscriptionChanged(any());
+        verify(subscriptionMock, timeout(500).atLeast(numberOfProtocols)).subscriptionChanged(any());
 
         // Publishing
         wsnClient.publish("all", "WSN");

--- a/src/test/java/no/ntnu/okse/protocol/MessageSendingTest.java
+++ b/src/test/java/no/ntnu/okse/protocol/MessageSendingTest.java
@@ -15,15 +15,21 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.net.URL;
+
 import static org.mockito.Mockito.*;
 
 @Test(singleThreaded = true)
 public class MessageSendingTest {
     @BeforeClass
-    public void setUp() throws InterruptedException {
+    public void setUp() throws InterruptedException, FileNotFoundException {
         CoreService cs = CoreService.getInstance();
         cs.registerService(MessageService.getInstance());
-        cs.bootProtocolServers();
+        InputStream resourceAsStream = CoreService.class.getResourceAsStream("/config/protocolservers.xml");
+        cs.bootProtocolServers(resourceAsStream);
         cs.boot();
         // Make sure servers have booted properly
         Thread.sleep(3000);


### PR DESCRIPTION
This prevents tests from failing because of local changes to protocolservers.xml
